### PR TITLE
Fix several hanging issues

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -174,6 +174,7 @@ var commands = {
       , title = slugify([].slice.call(arguments).join(' '));
     title = title ? curr + '-' + title : curr;
     create(title);
+    process.exit();
   }
 };
 

--- a/lib/set.js
+++ b/lib/set.js
@@ -206,7 +206,10 @@ Set.prototype._migrate = function(direction, fn, migrationName){
 
   function next(err, migration) {
     // error from previous migration
-    if (err) return fn(err);
+    if (err) {
+      console.error(err.toString());
+      process.exit(1);
+    }
 
     // done
     if (!migration) {

--- a/lib/set.js
+++ b/lib/set.js
@@ -65,7 +65,8 @@ Set.prototype.load = function(fn){
 
 var path = require('path');
 // get the config file path from env variable
-var configPath = path.resolve(process.env.NODE_MONGOOSE_MIGRATIONS_CONFIG);
+var configFile = process.env.NODE_MONGOOSE_MIGRATIONS_CONFIG || process.cwd() + '/config/migrations.js'
+var configPath = path.resolve(configFile);
 var mongoose = require('mongoose');
 var json = require(configPath);
 var env = process.env.NODE_ENV || 'development';

--- a/lib/set.js
+++ b/lib/set.js
@@ -63,53 +63,51 @@ Set.prototype.load = function(fn){
   this.connect(fn, 'new');
 };
 
+var path = require('path');
+// get the config file path from env variable
+var configPath = path.resolve(process.env.NODE_MONGOOSE_MIGRATIONS_CONFIG);
+var mongoose = require('mongoose');
+var json = require(configPath);
+var env = process.env.NODE_ENV || 'development';
+var config = json[env];
+var Schema = mongoose.Schema;
+var MigrationSchema = new Schema(config.schema);
+var Migration;
+mongoose.connect(config.db);
+
 /**
  * Connect to mongo
  */
-
 Set.prototype.connect = function(fn, type) {
-  var path = require('path');
   var self = this;
-  // get the config file path from env variable
-  var configPath = path.resolve(process.env.NODE_MONGOOSE_MIGRATIONS_CONFIG);
-  var mongoose = require('mongoose');
-  var json = require(configPath);
-  var env = process.env.NODE_ENV || 'development';
-  var config = json[env];
-  var db = mongoose.createConnection(config.db);
-  var Schema = mongoose.Schema;
-  var MigrationSchema = new Schema(config.schema);
-  var Migration;
 
-  db.on('connected', function () {
+  if (type) {
+    Migration = mongoose.model(config.modelName, MigrationSchema);
+  } else {
+    Migration = mongoose.model(config.modelName);
+  }
+
+  Migration.findOne().exec(function (err, doc) {
+    if (err) return fn(err);
+
     if (type) {
-      Migration = mongoose.model(config.modelName, MigrationSchema);
-    } else {
-      Migration = mongoose.model(config.modelName);
-    }
-
-    Migration.findOne().exec(function (err, doc) {
-      if (err) return fn(err);
-
-      if (type) {
-        try {
-          var obj = doc && doc.migration
-            ? doc.migration
-            : { pos: 0, migrations: [] }
-          fn(null, obj);
-        } catch (err) {
-          fn(err);
-        }
-      } else {
-        if (!doc) {
-          var m = new Migration({ migration: self });
-          m.save(cb);
-        } else {
-          doc.migration = self;
-          doc.save(cb);
-        }
+      try {
+        var obj = doc && doc.migration
+          ? doc.migration
+          : { pos: 0, migrations: [] }
+        fn(null, obj);
+      } catch (err) {
+        fn(err);
       }
-    });
+    } else {
+      if (!doc) {
+        var m = new Migration({ migration: self });
+        m.save(cb);
+      } else {
+        doc.migration = self;
+        doc.save(cb);
+      }
+    }
   });
 
   function cb(err) {
@@ -150,14 +148,16 @@ Set.prototype.up = function(fn, migrationName){
 
 Set.prototype.migrate = function(direction, fn, migrationName){
   var self = this;
-  fn = fn || function(){};
-  this.load(function(err, obj){
-    if (err) {
-      if ('ENOENT' != err.code) return fn(err);
-    } else {
-      self.pos = obj.pos;
-    }
-    self._migrate(direction, fn, migrationName);
+  mongoose.connection.once('open', function() {
+    fn = fn || function(){};
+    self.load(function(err, obj){
+      if (err) {
+        if ('ENOENT' != err.code) return fn(err);
+      } else {
+        self.pos = obj.pos;
+      }
+      self._migrate(direction, fn, migrationName);
+    });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-migrate",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Abstract migration framework for node",
   "keywords": [
     "migrate",


### PR DESCRIPTION
When I tried to use this package, I had lots of problems.  It was throwing errors because it was trying to open the same mongo connection twice, it would just hang when migrations were complete.  It would hang silently if the migrations threw an error, never displaying the error, and the necessity to always set the configuration file in an environment variable makes working with a team much more difficult.  So this pull request addresses all of these issues.  It will now exit properly when migrations have finished.  If a migration throws an error up the stack, it will log that error to the console and exit.  It only tries to connect to MongoDB once, and if the environment variable for the configuration file is not defined, it will default to ./config/migrations.js.  

