### PR TITLE
Add force option to be able to skip migration function routines

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -43,6 +43,7 @@ var usage = [
   , '     down   [name]    migrate down till given migration'
   , '     up     [name]    migrate up till given migration (the default command)'
   , '     create [title]   create a new migration file with optional [title]'
+  , '     force  [name]    set the current migration state without running up/down'
   , ''
 ].join('\n');
 
@@ -175,6 +176,14 @@ var commands = {
     title = title ? curr + '-' + title : curr;
     create(title);
     process.exit();
+  },
+
+  /**
+   * force [name]
+   */
+
+  force: function(migrationName){
+    performMigration('up', migrationName, true);
   }
 };
 
@@ -208,7 +217,7 @@ function create(name) {
  * @param {Number} direction
  */
 
-function performMigration(direction, migrationName) {
+function performMigration(direction, migrationName, force) {
   migrate('migrations/.migrate');
   var all = migrations();
   all.forEach(function(path){
@@ -219,6 +228,10 @@ function performMigration(direction, migrationName) {
   if (!all.length) process.exit();
 
   var set = migrate();
+
+  if (force) {
+    set.force = true;
+  }
 
   set.on('migration', function(migration, direction){
     log(direction, migration.title);

--- a/lib/set.js
+++ b/lib/set.js
@@ -219,9 +219,13 @@ Set.prototype._migrate = function(direction, fn, migrationName){
     }
 
     self.emit('migration', migration, direction);
-    migration[direction](function(err){
-      next(err, migrations.shift());
-    });
+    if (self.force) {
+      next(null, migrations.shift());
+    } else {
+      migration[direction](function(err){
+        next(err, migrations.shift());
+      });
+    }
   }
 
   next(null, migrations.shift());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-migrate",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Abstract migration framework for node",
   "keywords": [
     "migrate",
@@ -14,7 +14,7 @@
   "repository": "git://github.com/madhums/mongoose-migrate",
   "bin": { "mongoose-migrate": "./bin/migrate" },
   "dependencies" : {
-    "mongoose": "4.1.x"
+    "mongoose": "^5.0.0"
   },
   "devDependencies": {
     "should": ">= 0.0.1"


### PR DESCRIPTION
Adds the ability to run migrate with the following option

```
force  [name]    set the current migration state without running up/down
```